### PR TITLE
Use global logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ golog is a logging package to write warnings, errors, requests, or any message t
 
 ### NewLogger
 
-`func NewLogger(app, version string) *Logger`
+`func Init(app, version string)`
 
-Create a new Logger instance with the provided app name and version.
+Initialize the global logger with the provided app name and version.
 
 ### Log
 
-`func (l *Logger) Log(msg string)`
+`func Log(msg string)`
 
 Log any message to standard out.
 
@@ -25,7 +25,7 @@ time="2016-01-18T13:49:17-05:00" level=info app=golog msg="test message" v=v0.0.
 
 ### LogError
 
-`func (l *Logger) LogError(err error)`
+`func LogError(err error)`
 
 Log an error to standard out.
 
@@ -36,7 +36,7 @@ time="2016-01-18T13:49:17-05:00" level=error app=golog msg="error message" file=
 
 ### LogWarning
 
-`func (l *Logger) LogWarning(msg string)`
+`func LogWarning(msg string)`
 
 Log a warning message to standard out.
 
@@ -45,11 +45,9 @@ Format:
 time="2016-01-18T13:49:17-05:00" level=warn app=golog msg="warning message" v=v0.0.1
 ```
 
-### LogRequestMiddleware
+### LoggingMiddleware
 
-`func LogRequestMiddleware(l *Logger) func(http.Handler) http.Handler`
-
-Return a middleware function (`func(http.Handler) http.Handler`) that logs each request to standard out.
+LoggingMiddleware is a middleware function (`func(http.Handler) http.Handler`) that logs each request to standard out.
 
 Format:
 ```

--- a/golog_suite_test.go
+++ b/golog_suite_test.go
@@ -1,6 +1,8 @@
 package golog_test
 
 import (
+	. "github.com/crowdriff/golog"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -11,3 +13,12 @@ func TestGolog(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Golog Suite")
 }
+
+var _ = BeforeSuite(func() {
+
+	Ω(func() {
+		Log("test")
+	}).Should(Panic())
+
+	Init("golog", "v1")
+})

--- a/golog_test.go
+++ b/golog_test.go
@@ -14,17 +14,19 @@ import (
 var _ = Describe("Golog", func() {
 	Context("NewLogger", func() {
 		It("should create a Logger", func() {
-			l := NewLogger("golog", "v1")
-			Ω(l).ShouldNot(BeNil())
+			Init("golog", "v1")
+			Ω(func() {
+				Log("test")
+			}).ShouldNot(Panic())
 		})
 	})
 
 	Context("Log", func() {
 		It("should log a message with the proper format", func() {
 			var buf bytes.Buffer
-			l := NewLogger("golog", "v1")
-			l.SetOutput(&buf)
-			l.Log("test message")
+			Init("golog", "v1")
+			SetOutput(&buf)
+			Log("test message")
 			out := buf.String()
 			Ω(strings.Contains(out, "level=info")).Should(BeTrue())
 			Ω(strings.Contains(out, "app=golog")).Should(BeTrue())
@@ -37,9 +39,9 @@ var _ = Describe("Golog", func() {
 	Context("Log Error", func() {
 		It("should log an error with the proper format", func() {
 			var buf bytes.Buffer
-			l := NewLogger("golog", "v1")
-			l.SetOutput(&buf)
-			l.LogError(errors.New("test error"))
+			Init("golog", "v1")
+			SetOutput(&buf)
+			LogError(errors.New("test error"))
 			out := buf.String()
 			Ω(strings.Contains(out, "level=error")).Should(BeTrue())
 			Ω(strings.Contains(out, "app=golog")).Should(BeTrue())
@@ -54,9 +56,9 @@ var _ = Describe("Golog", func() {
 	Context("Log Warning", func() {
 		It("should log a warning with the proper format", func() {
 			var buf bytes.Buffer
-			l := NewLogger("golog", "v1")
-			l.SetOutput(&buf)
-			l.LogWarning("test warning")
+			Init("golog", "v1")
+			SetOutput(&buf)
+			LogWarning("test warning")
 			out := buf.String()
 			Ω(strings.Contains(out, "level=warn")).Should(BeTrue())
 			Ω(strings.Contains(out, "app=golog")).Should(BeTrue())

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-version=0.1.0
+version=0.2.0
 
 .PHONY: all
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -27,11 +27,10 @@ func (h *fakeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 var _ = Describe("Middleware", func() {
 	It("should log the request with middleware and the X-Forwarded-For ip address", func() {
 		var buf bytes.Buffer
-		l := NewLogger("golog", "v1")
-		l.SetOutput(&buf)
+		SetOutput(&buf)
 
 		h := &fakeHTTPHandler{http.StatusOK, 100}
-		f := LogRequestMiddleware(l)(h)
+		f := LoggingMiddleware(h)
 
 		wr := httptest.NewRecorder()
 		r, err := http.NewRequest("GET", "http://localhost/path?query=10", nil)
@@ -54,11 +53,10 @@ var _ = Describe("Middleware", func() {
 
 	It("should log the request with middleware and the X-Real-IP ip address", func() {
 		var buf bytes.Buffer
-		l := NewLogger("golog", "v1")
-		l.SetOutput(&buf)
+		SetOutput(&buf)
 
 		h := &fakeHTTPHandler{http.StatusBadRequest, 2345}
-		f := LogRequestMiddleware(l)(h)
+		f := LoggingMiddleware(h)
 
 		wr := httptest.NewRecorder()
 		r, err := http.NewRequest("POST", "http://localhost/path?query=10#yolo", nil)


### PR DESCRIPTION
This update no longer returns a Logger instance. Instead, a global
logger object is used.
